### PR TITLE
フォロー時、管理者用のアラート文が誤表示される 

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -13,7 +13,9 @@ class RelationshipsController < ApplicationController
 
 	private
 	def admin_limit
-		flash[:alert] = "管理者ユーザーはフォローできません。"
-    	redirect_back(fallback_location: posts_path) if current_user.admin?
+		if current_user.admin?
+			flash[:alert] = "管理者ユーザーはフォローできません。"
+    		redirect_back(fallback_location: posts_path)
+    	end
   	end
 end


### PR DESCRIPTION
一般ユーザーがユーザーをフォローする時、管理者用のアラート文誤表示される。