### PR TITLE
フォロー機能が非同期通信されていない

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,17 +1,19 @@
 class RelationshipsController < ApplicationController
 	before_action :authenticate_user!
+	before_action :set_user
 	before_action :admin_limit
 
 	def follow
-		current_user.follow(params[:id])
-		redirect_back(fallback_location: user_path(params[:id]))
+		current_user.follow(@user.id)
 	end
 	def unfollow
-		current_user.unfollow(params[:id])
-		redirect_back(fallback_location: user_path(params[:id]))
+		current_user.unfollow(@user.id)
 	end
 
 	private
+	def set_user
+  		@user = User.find(params[:id])
+  	end
 	def admin_limit
 		if current_user.admin?
 			flash[:alert] = "管理者ユーザーはフォローできません。"


### PR DESCRIPTION
- followとunfollowのアクション内で記述されていたredirect_backを削除
- インスタンス変数を定義